### PR TITLE
Improve package.json and bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,27 @@
 {
   "name": "backbone-validator",
+  "description": "Backbone model validator allows you to define validation rules for model and utilize it for model-standalone validation or bind its events to the view so you can display errors if needed.",
   "version": "0.2.4",
+  "authors": [
+    {
+      "name": "fantactuka",
+      "homepage": "https://github.com/fantactuka"
+    }
+  ],
+  "homepage": "http://fantactuka.github.io/backbone-validator/",
   "main": "backbone-validator.js",
+  "keywords": [
+    "jquery",
+    "javascript",
+    "backbone",
+    "validation",
+    "validator"
+  ],
+  "dependencies": {
+    "jquery": "~2.1.0",
+    "backbone": "~1.1.2",
+    "underscore": "~1.6.0"
+  },  
   "ignore": [
     "**/.*",
     "node_modules",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,48 @@
 {
-  "name": "the-web-app",
+  "name": "backbone-validator.js",
+  "title": "Backbone Validator",
+  "description": "Backbone model validator allows you to define validation rules for model and utilize it for model-standalone validation or bind its events to the view so you can display errors if needed.",
   "version": "0.2.4",
+  "main": "backbone-validator.js",
+  "homepage": "http://fantactuka.github.io/backbone-validator/",
+  "author": {
+    "name": "fantactuka",
+    "url": "https://github.com/fantactuka"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/fantactuka/backbone-validator.git"
+  },
+  "keywords": [
+    "jquery",
+    "javascript",
+    "backbone",
+    "validation",
+    "validator"
+  ],
+  "bugs": {
+    "url": "https://github.com/fantactuka/backbone-validator/issues"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/fantactuka/backbone-validator/blob/master/LICENSE"
+    }
+  ],  
   "scripts": {
     "test": "grunt test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "jquery": "~2.1.0",
+    "backbone": "~1.1.2",
+    "underscore": "~1.6.0"
+  },
   "devDependencies": {
-    "grunt": "0.4.0",
-    "grunt-karma": "0.4.4",
-    "grunt-version": "0.2.1",
-    "grunt-contrib-jshint": "0.1.1",
-    "grunt-contrib-uglify": "0.1.1",
-    "grunt-contrib-qunit": "0.1.1"
+    "grunt": "~0.4.0",
+    "grunt-karma": "~0.4.4",
+    "grunt-version": "~0.2.1",
+    "grunt-contrib-jshint": "~0.1.1",
+    "grunt-contrib-uglify": "~0.1.1",
+    "grunt-contrib-qunit": "~0.1.1"
   }
 }


### PR DESCRIPTION
This PR adds the required and recommended information to `package.json` so that this module can be published to NPM. I also took the liberty to update `bower.json` with some recommended information and dependencies.

I named the package "backbone-validator.js" because both "backbone-validator" and "backbone.validator" are already taken in npm. "backbone-validator.js" however seems to be available at the moment. Feel free to change it though.

To publish the package to npm, please follow the guide here: https://gist.github.com/coolaj86/1318304. But to be honest, you can skip the pakmanager stuff - and also - we already have a package.json in place. So you really only need to create a user on npm and publish.

Also, FYI: http://stackoverflow.com/questions/13507763/do-i-need-to-publish-to-npm-every-time-i-update-a-package-available-via-git
