### PR TITLE
Add model validator and improve collection validator

### DIFF
--- a/backbone-validator.js
+++ b/backbone-validator.js
@@ -346,6 +346,22 @@
       }
     },
     {
+      name: 'model',
+      fn: function(model, expectation) {
+        if (expectation === false || !model) {
+          return true;
+        }
+
+        var Model = typeof expectation === 'function' ? expectation : null;
+        
+        model = !model.attributes && Model ? new Model(model) : model;
+
+        var errors = model.validate();
+
+        return errors || true;
+      }
+    },
+    {
       name: 'minLength',
       message: 'Is too short',
       fn: function(value, expectation) {

--- a/spec/backbone-validator-spec.js
+++ b/spec/backbone-validator-spec.js
@@ -275,6 +275,47 @@ describe('Backbone.Validator', function() {
       });
 
     });
+
+    describe('model', function() {
+      var User = Backbone.Model.extend({
+        validation: {
+          name: {
+            required: true
+          }
+        }
+      });
+
+      expectToPass('model', new User({ name: 'Sam' }));
+      
+      expectToPass('model', new User({ name: '' }), false);
+
+      expectToPass('model', undefined);
+
+      expectToPass('model', null);    
+
+      expectToFail('model', new User({ name: '' }), true, { name: [ 'Is required' ] });
+      
+      expectToPass('model', { name: 'Sam' }, User);
+
+      expectToFail('model', { name: '' }, User, { name: [ 'Is required' ] });
+
+      describe('using nested models', function() {
+        var Comment = Backbone.Model.extend({
+          validation: {
+            user: {
+              model: User
+            }
+          }
+        });
+
+        expectToPass('model', new Comment({ user: new User({ name: 'Sam'} ) }));
+        
+        expectToPass('model', { user: { name: 'Sam'} }, Comment);
+
+        expectToFail('model', { user: { name: ''} }, Comment, { user: [ { name: ['Is required'] } ] });
+      });
+
+    });
   });
 
   describe('#validate', function() {


### PR DESCRIPTION
This PR brings quite a few improvements (all backwards-compatible).
1. Do not try to validate collection (or model) if value is falsy, as reported in #21
2. Allow specifying Collection constructor, as discussed in #22
3. Introduce a model validator, which works pretty much the same as collection validator, expect for models.

``` javascript
var Comment = Backbone.Model.extend({
  validation: {
    user: {
      model: User
    }
  }
});
```

The last 2 are pretty powerful features. The good thing is - they do not affect the codebase a lot - just a few lines of code, but a lot of flexibility.

I have also provided the tests for all of the above cases.
