### PR TITLE
Why is the triggerValidation deferred?

### DIFF
--- a/backbone-validator.js
+++ b/backbone-validator.js
@@ -173,7 +173,7 @@
           Validator.ModelCallbacks.processErrors(errors);
 
         if (!options.silent) {
-          _.defer(_.bind(this.triggerValidated, this), attrs, errors);
+          this.triggerValidated(attrs, errors);
         }
 
         return options && options.suppress ? null : errors;


### PR DESCRIPTION
When calling `model.validate` programmatically or simply debugging the validation, the defered trigger always causes some confusion. Maybe I am missing something important but it there any good reason why the `validated` event needs to be defered?

This pull request does not really change the behavior of the validation but helps to determine who triggered the validation while debugging.
