### PR TITLE
Update underscore version (1.6.0 -> 1.7.0)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "jquery": "~2.1.0",
     "backbone": "~1.1.2",
-    "underscore": "~1.6.0"
+    "underscore": "~1.7.0"
   },  
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Hi,

Underscore.js has released a new version in the 1.x branch.
