### PR TITLE
Loosen dependency version restriction 

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "jquery": "~2.1.0",
-    "backbone": "~1.1.2",
-    "underscore": "~1.6.0"
+    "jquery": "^2.1.0",
+    "backbone": "^1.1.2",
+    "underscore": "^1.6.0"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
### Problem

Currently this library doesn't support [jQuery v2.2.0](https://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/) because [the `package.json` of this project specifies `jquery` version with `~` operator](https://github.com/fantactuka/backbone-validator/blob/53d659067fa7880ddf68208d127ca43f6657c87f/package.json#L36).
### Solution

I replaced `~` with [`^`](https://nodesource.com/blog/semver-tilde-and-caret/) to let this library work with jQuery v2.2.0.
